### PR TITLE
Add emscripten toolset to Boost.Build and emscripten.bat to build boost

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,504 +1,504 @@
 [submodule "system"]
 	path = libs/system
-	url = ../system.git
+	url = https://github.com/boostorg/system.git
 	fetchRecurseSubmodules = on-demand
 [submodule "multi_array"]
 	path = libs/multi_array
-	url = ../multi_array.git
+	url = https://github.com/boostorg/multi_array.git
 	fetchRecurseSubmodules = on-demand
 [submodule "math"]
 	path = libs/math
-	url = ../math.git
+	url = https://github.com/boostorg/math.git
 	fetchRecurseSubmodules = on-demand
 [submodule "smart_ptr"]
 	path = libs/smart_ptr
-	url = ../smart_ptr.git
+	url = https://github.com/boostorg/smart_ptr.git
 	fetchRecurseSubmodules = on-demand
 [submodule "parameter"]
 	path = libs/parameter
-	url = ../parameter.git
+	url = https://github.com/boostorg/parameter.git
 	fetchRecurseSubmodules = on-demand
 [submodule "algorithm"]
 	path = libs/algorithm
-	url = ../algorithm.git
+	url = https://github.com/boostorg/algorithm.git
 	fetchRecurseSubmodules = on-demand
 [submodule "any"]
 	path = libs/any
-	url = ../any.git
+	url = https://github.com/boostorg/any.git
 	fetchRecurseSubmodules = on-demand
 [submodule "concept_check"]
 	path = libs/concept_check
-	url = ../concept_check.git
+	url = https://github.com/boostorg/concept_check.git
 	fetchRecurseSubmodules = on-demand
 [submodule "python"]
 	path = libs/python
-	url = ../python.git
+	url = https://github.com/boostorg/python.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tti"]
 	path = libs/tti
-	url = ../tti.git
+	url = https://github.com/boostorg/tti.git
 	fetchRecurseSubmodules = on-demand
 [submodule "functional"]
 	path = libs/functional
-	url = ../functional.git
+	url = https://github.com/boostorg/functional.git
 	fetchRecurseSubmodules = on-demand
 [submodule "config"]
 	path = libs/config
-	url = ../config.git
+	url = https://github.com/boostorg/config.git
 	fetchRecurseSubmodules = on-demand
 [submodule "log"]
 	path = libs/log
-	url = ../log.git
+	url = https://github.com/boostorg/log.git
 	fetchRecurseSubmodules = on-demand
 [submodule "interprocess"]
 	path = libs/interprocess
-	url = ../interprocess.git
+	url = https://github.com/boostorg/interprocess.git
 	fetchRecurseSubmodules = on-demand
 [submodule "exception"]
 	path = libs/exception
-	url = ../exception.git
+	url = https://github.com/boostorg/exception.git
 	fetchRecurseSubmodules = on-demand
 [submodule "foreach"]
 	path = libs/foreach
-	url = ../foreach.git
+	url = https://github.com/boostorg/foreach.git
 	fetchRecurseSubmodules = on-demand
 [submodule "spirit"]
 	path = libs/spirit
-	url = ../spirit.git
+	url = https://github.com/boostorg/spirit.git
 	fetchRecurseSubmodules = on-demand
 [submodule "io"]
 	path = libs/io
-	url = ../io.git
+	url = https://github.com/boostorg/io.git
 	fetchRecurseSubmodules = on-demand
 [submodule "disjoint_sets"]
 	path = libs/disjoint_sets
-	url = ../disjoint_sets.git
+	url = https://github.com/boostorg/disjoint_sets.git
 	fetchRecurseSubmodules = on-demand
 [submodule "units"]
 	path = libs/units
-	url = ../units.git
+	url = https://github.com/boostorg/units.git
 	fetchRecurseSubmodules = on-demand
 [submodule "preprocessor"]
 	path = libs/preprocessor
-	url = ../preprocessor.git
+	url = https://github.com/boostorg/preprocessor.git
 	fetchRecurseSubmodules = on-demand
 [submodule "format"]
 	path = libs/format
-	url = ../format.git
+	url = https://github.com/boostorg/format.git
 	fetchRecurseSubmodules = on-demand
 [submodule "xpressive"]
 	path = libs/xpressive
-	url = ../xpressive.git
+	url = https://github.com/boostorg/xpressive.git
 	fetchRecurseSubmodules = on-demand
 [submodule "integer"]
 	path = libs/integer
-	url = ../integer.git
+	url = https://github.com/boostorg/integer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "thread"]
 	path = libs/thread
-	url = ../thread.git
+	url = https://github.com/boostorg/thread.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tokenizer"]
 	path = libs/tokenizer
-	url = ../tokenizer.git
+	url = https://github.com/boostorg/tokenizer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "timer"]
 	path = libs/timer
-	url = ../timer.git
+	url = https://github.com/boostorg/timer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "inspect"]
 	path = tools/inspect
-	url = ../inspect.git
+	url = https://github.com/boostorg/inspect.git
 	fetchRecurseSubmodules = on-demand
 [submodule "boostbook"]
 	path = tools/boostbook
-	url = ../boostbook.git
+	url = https://github.com/boostorg/boostbook.git
 	fetchRecurseSubmodules = on-demand
 [submodule "regex"]
 	path = libs/regex
-	url = ../regex.git
+	url = https://github.com/boostorg/regex.git
 	fetchRecurseSubmodules = on-demand
 [submodule "crc"]
 	path = libs/crc
-	url = ../crc.git
+	url = https://github.com/boostorg/crc.git
 	fetchRecurseSubmodules = on-demand
 [submodule "random"]
 	path = libs/random
-	url = ../random.git
+	url = https://github.com/boostorg/random.git
 	fetchRecurseSubmodules = on-demand
 [submodule "serialization"]
 	path = libs/serialization
-	url = ../serialization.git
+	url = https://github.com/boostorg/serialization.git
 	fetchRecurseSubmodules = on-demand
 [submodule "test"]
 	path = libs/test
-	url = ../test.git
+	url = https://github.com/boostorg/test.git
 	fetchRecurseSubmodules = on-demand
 [submodule "date_time"]
 	path = libs/date_time
-	url = ../date_time.git
+	url = https://github.com/boostorg/date_time.git
 	fetchRecurseSubmodules = on-demand
 [submodule "logic"]
 	path = libs/logic
-	url = ../logic.git
+	url = https://github.com/boostorg/logic.git
 	fetchRecurseSubmodules = on-demand
 [submodule "graph"]
 	path = libs/graph
-	url = ../graph.git
+	url = https://github.com/boostorg/graph.git
 	fetchRecurseSubmodules = on-demand
 [submodule "numeric_conversion"]
 	path = libs/numeric/conversion
-	url = ../numeric_conversion.git
+	url = https://github.com/boostorg/numeric_conversion.git
 	fetchRecurseSubmodules = on-demand
 [submodule "lambda"]
 	path = libs/lambda
-	url = ../lambda.git
+	url = https://github.com/boostorg/lambda.git
 	fetchRecurseSubmodules = on-demand
 [submodule "mpl"]
 	path = libs/mpl
-	url = ../mpl.git
+	url = https://github.com/boostorg/mpl.git
 	fetchRecurseSubmodules = on-demand
 [submodule "typeof"]
 	path = libs/typeof
-	url = ../typeof.git
+	url = https://github.com/boostorg/typeof.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tuple"]
 	path = libs/tuple
-	url = ../tuple.git
+	url = https://github.com/boostorg/tuple.git
 	fetchRecurseSubmodules = on-demand
 [submodule "utility"]
 	path = libs/utility
-	url = ../utility.git
+	url = https://github.com/boostorg/utility.git
 	fetchRecurseSubmodules = on-demand
 [submodule "dynamic_bitset"]
 	path = libs/dynamic_bitset
-	url = ../dynamic_bitset.git
+	url = https://github.com/boostorg/dynamic_bitset.git
 	fetchRecurseSubmodules = on-demand
 [submodule "assign"]
 	path = libs/assign
-	url = ../assign.git
+	url = https://github.com/boostorg/assign.git
 	fetchRecurseSubmodules = on-demand
 [submodule "filesystem"]
 	path = libs/filesystem
-	url = ../filesystem.git
+	url = https://github.com/autodesk-forks/filesystem.git
 	fetchRecurseSubmodules = on-demand
 [submodule "function"]
 	path = libs/function
-	url = ../function.git
+	url = https://github.com/boostorg/function.git
 	fetchRecurseSubmodules = on-demand
 [submodule "conversion"]
 	path = libs/conversion
-	url = ../conversion.git
+	url = https://github.com/boostorg/conversion.git
 	fetchRecurseSubmodules = on-demand
 [submodule "optional"]
 	path = libs/optional
-	url = ../optional.git
+	url = https://github.com/boostorg/optional.git
 	fetchRecurseSubmodules = on-demand
 [submodule "property_tree"]
 	path = libs/property_tree
-	url = ../property_tree.git
+	url = https://github.com/boostorg/property_tree.git
 	fetchRecurseSubmodules = on-demand
 [submodule "bimap"]
 	path = libs/bimap
-	url = ../bimap.git
+	url = https://github.com/boostorg/bimap.git
 	fetchRecurseSubmodules = on-demand
 [submodule "variant"]
 	path = libs/variant
-	url = ../variant.git
+	url = https://github.com/boostorg/variant.git
 	fetchRecurseSubmodules = on-demand
 [submodule "array"]
 	path = libs/array
-	url = ../array.git
+	url = https://github.com/boostorg/array.git
 	fetchRecurseSubmodules = on-demand
 [submodule "iostreams"]
 	path = libs/iostreams
-	url = ../iostreams.git
+	url = https://github.com/boostorg/iostreams.git
 	fetchRecurseSubmodules = on-demand
 [submodule "multi_index"]
 	path = libs/multi_index
-	url = ../multi_index.git
+	url = https://github.com/boostorg/multi_index.git
 	fetchRecurseSubmodules = on-demand
 [submodule "bcp"]
 	path = tools/bcp
-	url = ../bcp.git
+	url = https://github.com/boostorg/bcp.git
 	fetchRecurseSubmodules = on-demand
 [submodule "ptr_container"]
 	path = libs/ptr_container
-	url = ../ptr_container.git
+	url = https://github.com/boostorg/ptr_container.git
 	fetchRecurseSubmodules = on-demand
 [submodule "statechart"]
 	path = libs/statechart
-	url = ../statechart.git
+	url = https://github.com/boostorg/statechart.git
 	fetchRecurseSubmodules = on-demand
 [submodule "static_assert"]
 	path = libs/static_assert
-	url = ../static_assert.git
+	url = https://github.com/boostorg/static_assert.git
 	fetchRecurseSubmodules = on-demand
 [submodule "range"]
 	path = libs/range
-	url = ../range.git
+	url = https://github.com/boostorg/range.git
 	fetchRecurseSubmodules = on-demand
 [submodule "signals"]
 	path = libs/signals
-	url = ../signals.git
+	url = https://github.com/boostorg/signals.git
 	fetchRecurseSubmodules = on-demand
 [submodule "rational"]
 	path = libs/rational
-	url = ../rational.git
+	url = https://github.com/boostorg/rational.git
 	fetchRecurseSubmodules = on-demand
 [submodule "tr1"]
 	path = libs/tr1
-	url = ../tr1.git
+	url = https://github.com/boostorg/tr1.git
 	fetchRecurseSubmodules = on-demand
 [submodule "iterator"]
 	path = libs/iterator
-	url = ../iterator.git
+	url = https://github.com/boostorg/iterator.git
 	fetchRecurseSubmodules = on-demand
 [submodule "build"]
 	path = tools/build
-	url = ../build.git
+	url = https://github.com/boostorg/build.git
 	fetchRecurseSubmodules = on-demand
 [submodule "quickbook"]
 	path = tools/quickbook
-	url = ../quickbook.git
+	url = https://github.com/boostorg/quickbook.git
 	fetchRecurseSubmodules = on-demand
 [submodule "graph_parallel"]
 	path = libs/graph_parallel
-	url = ../graph_parallel.git
+	url = https://github.com/boostorg/graph_parallel.git
 	fetchRecurseSubmodules = on-demand
 [submodule "property_map"]
 	path = libs/property_map
-	url = ../property_map.git
+	url = https://github.com/boostorg/property_map.git
 	fetchRecurseSubmodules = on-demand
 [submodule "program_options"]
 	path = libs/program_options
-	url = ../program_options.git
+	url = https://github.com/boostorg/program_options.git
 	fetchRecurseSubmodules = on-demand
 [submodule "detail"]
 	path = libs/detail
-	url = ../detail.git
+	url = https://github.com/boostorg/detail.git
 	fetchRecurseSubmodules = on-demand
 [submodule "interval"]
 	path = libs/numeric/interval
-	url = ../interval.git
+	url = https://github.com/boostorg/interval.git
 	fetchRecurseSubmodules = on-demand
 [submodule "ublas"]
 	path = libs/numeric/ublas
-	url = ../ublas.git
+	url = https://github.com/boostorg/ublas.git
 	fetchRecurseSubmodules = on-demand
 [submodule "wave"]
 	path = libs/wave
-	url = ../wave.git
+	url = https://github.com/boostorg/wave.git
 	fetchRecurseSubmodules = on-demand
 [submodule "type_traits"]
 	path = libs/type_traits
-	url = ../type_traits.git
+	url = https://github.com/boostorg/type_traits.git
 	fetchRecurseSubmodules = on-demand
 [submodule "compatibility"]
 	path = libs/compatibility
-	url = ../compatibility.git
+	url = https://github.com/boostorg/compatibility.git
 	fetchRecurseSubmodules = on-demand
 [submodule "bind"]
 	path = libs/bind
-	url = ../bind.git
+	url = https://github.com/boostorg/bind.git
 	fetchRecurseSubmodules = on-demand
 [submodule "pool"]
 	path = libs/pool
-	url = ../pool.git
+	url = https://github.com/boostorg/pool.git
 	fetchRecurseSubmodules = on-demand
 [submodule "proto"]
 	path = libs/proto
-	url = ../proto.git
+	url = https://github.com/boostorg/proto.git
 	fetchRecurseSubmodules = on-demand
 [submodule "fusion"]
 	path = libs/fusion
-	url = ../fusion.git
+	url = https://github.com/boostorg/fusion.git
 	fetchRecurseSubmodules = on-demand
 [submodule "function_types"]
 	path = libs/function_types
-	url = ../function_types.git
+	url = https://github.com/boostorg/function_types.git
 	fetchRecurseSubmodules = on-demand
 [submodule "gil"]
 	path = libs/gil
-	url = ../gil.git
+	url = https://github.com/boostorg/gil.git
 	fetchRecurseSubmodules = on-demand
 [submodule "intrusive"]
 	path = libs/intrusive
-	url = ../intrusive.git
+	url = https://github.com/boostorg/intrusive.git
 	fetchRecurseSubmodules = on-demand
 [submodule "asio"]
 	path = libs/asio
-	url = ../asio.git
+	url = https://github.com/boostorg/asio.git
 	fetchRecurseSubmodules = on-demand
 [submodule "uuid"]
 	path = libs/uuid
-	url = ../uuid.git
+	url = https://github.com/boostorg/uuid.git
 	fetchRecurseSubmodules = on-demand
 [submodule "litre"]
 	path = tools/litre
-	url = ../litre.git
+	url = https://github.com/boostorg/litre.git
 	fetchRecurseSubmodules = on-demand
 [submodule "circular_buffer"]
 	path = libs/circular_buffer
-	url = ../circular_buffer.git
+	url = https://github.com/boostorg/circular_buffer.git
 	fetchRecurseSubmodules = on-demand
 [submodule "mpi"]
 	path = libs/mpi
-	url = ../mpi.git
+	url = https://github.com/boostorg/mpi.git
 	fetchRecurseSubmodules = on-demand
 [submodule "unordered"]
 	path = libs/unordered
-	url = ../unordered.git
+	url = https://github.com/boostorg/unordered.git
 	fetchRecurseSubmodules = on-demand
 [submodule "signals2"]
 	path = libs/signals2
-	url = ../signals2.git
+	url = https://github.com/boostorg/signals2.git
 	fetchRecurseSubmodules = on-demand
 [submodule "accumulators"]
 	path = libs/accumulators
-	url = ../accumulators.git
+	url = https://github.com/boostorg/accumulators.git
 	fetchRecurseSubmodules = on-demand
 [submodule "atomic"]
 	path = libs/atomic
-	url = ../atomic.git
+	url = https://github.com/boostorg/atomic.git
 	fetchRecurseSubmodules = on-demand
 [submodule "scope_exit"]
 	path = libs/scope_exit
-	url = ../scope_exit.git
+	url = https://github.com/boostorg/scope_exit.git
 	fetchRecurseSubmodules = on-demand
 [submodule "flyweight"]
 	path = libs/flyweight
-	url = ../flyweight.git
+	url = https://github.com/boostorg/flyweight.git
 	fetchRecurseSubmodules = on-demand
 [submodule "icl"]
 	path = libs/icl
-	url = ../icl.git
+	url = https://github.com/boostorg/icl.git
 	fetchRecurseSubmodules = on-demand
 [submodule "predef"]
 	path = libs/predef
-	url = ../predef.git
+	url = https://github.com/boostorg/predef.git
 	fetchRecurseSubmodules = on-demand
 [submodule "chrono"]
 	path = libs/chrono
-	url = ../chrono.git
+	url = https://github.com/boostorg/chrono.git
 	fetchRecurseSubmodules = on-demand
 [submodule "polygon"]
 	path = libs/polygon
-	url = ../polygon.git
+	url = https://github.com/boostorg/polygon.git
 	fetchRecurseSubmodules = on-demand
 [submodule "msm"]
 	path = libs/msm
-	url = ../msm.git
+	url = https://github.com/boostorg/msm.git
 	fetchRecurseSubmodules = on-demand
 [submodule "heap"]
 	path = libs/heap
-	url = ../heap.git
+	url = https://github.com/boostorg/heap.git
 	fetchRecurseSubmodules = on-demand
 [submodule "coroutine"]
 	path = libs/coroutine
-	url = ../coroutine.git
+	url = https://github.com/boostorg/coroutine.git
 	fetchRecurseSubmodules = on-demand
 [submodule "coroutine2"]
 	path = libs/coroutine2
-	url = ../coroutine2.git
+	url = https://github.com/boostorg/coroutine2.git
 	fetchRecurseSubmodules = on-demand
 [submodule "ratio"]
 	path = libs/ratio
-	url = ../ratio.git
+	url = https://github.com/boostorg/ratio.git
 	fetchRecurseSubmodules = on-demand
 [submodule "odeint"]
 	path = libs/numeric/odeint
-	url = ../odeint.git
+	url = https://github.com/boostorg/odeint.git
 	fetchRecurseSubmodules = on-demand
 [submodule "geometry"]
 	path = libs/geometry
-	url = ../geometry.git
+	url = https://github.com/boostorg/geometry.git
 	fetchRecurseSubmodules = on-demand
 [submodule "phoenix"]
 	path = libs/phoenix
-	url = ../phoenix.git
+	url = https://github.com/boostorg/phoenix.git
 	fetchRecurseSubmodules = on-demand
 [submodule "move"]
 	path = libs/move
-	url = ../move.git
+	url = https://github.com/boostorg/move.git
 	fetchRecurseSubmodules = on-demand
 [submodule "locale"]
 	path = libs/locale
-	url = ../locale.git
+	url = https://github.com/boostorg/locale.git
 	fetchRecurseSubmodules = on-demand
 [submodule "auto_index"]
 	path = tools/auto_index
-	url = ../auto_index.git
+	url = https://github.com/boostorg/auto_index.git
 	fetchRecurseSubmodules = on-demand
 [submodule "container"]
 	path = libs/container
-	url = ../container.git
+	url = https://github.com/boostorg/container.git
 	fetchRecurseSubmodules = on-demand
 [submodule "local_function"]
 	path = libs/local_function
-	url = ../local_function.git
+	url = https://github.com/boostorg/local_function.git
 	fetchRecurseSubmodules = on-demand
 [submodule "context"]
 	path = libs/context
-	url = ../context.git
+	url = https://github.com/boostorg/context.git
 	fetchRecurseSubmodules = on-demand
 [submodule "type_erasure"]
 	path = libs/type_erasure
-	url = ../type_erasure.git
+	url = https://github.com/boostorg/type_erasure.git
 	fetchRecurseSubmodules = on-demand
 [submodule "multiprecision"]
 	path = libs/multiprecision
-	url = ../multiprecision.git
+	url = https://github.com/boostorg/multiprecision.git
 	fetchRecurseSubmodules = on-demand
 [submodule "lockfree"]
 	path = libs/lockfree
-	url = ../lockfree.git
+	url = https://github.com/boostorg/lockfree.git
 	fetchRecurseSubmodules = on-demand
 [submodule "assert"]
 	path = libs/assert
-	url = ../assert.git
+	url = https://github.com/boostorg/assert.git
 	fetchRecurseSubmodules = on-demand
 [submodule "align"]
 	path = libs/align
-	url = ../align.git
+	url = https://github.com/boostorg/align.git
 	fetchRecurseSubmodules = on-demand
 [submodule "type_index"]
 	path = libs/type_index
-	url = ../type_index.git
+	url = https://github.com/boostorg/type_index.git
 	fetchRecurseSubmodules = on-demand
 [submodule "core"]
 	path = libs/core
-	url = ../core.git
+	url = https://github.com/boostorg/core.git
 	fetchRecurseSubmodules = on-demand
 [submodule "throw_exception"]
 	path = libs/throw_exception
-	url = ../throw_exception.git
+	url = https://github.com/boostorg/throw_exception.git
 	fetchRecurseSubmodules = on-demand
 [submodule "winapi"]
 	path = libs/winapi
-	url = ../winapi.git
+	url = https://github.com/boostorg/winapi.git
 	fetchRecurseSubmodules = on-demand
 [submodule "boostdep"]
 	path = tools/boostdep
-	url = ../boostdep.git
+	url = https://github.com/boostorg/boostdep.git
 	fetchRecurseSubmodules = on-demand
 [submodule "lexical_cast"]
 	path = libs/lexical_cast
-	url = ../lexical_cast.git
+	url = https://github.com/boostorg/lexical_cast.git
 	fetchRecurseSubmodules = on-demand
 [submodule "sort"]
 	path = libs/sort
-	url = ../sort.git
+	url = https://github.com/boostorg/sort.git
 	branch = master
 [submodule "convert"]
 	path = libs/convert
-	url = ../convert.git
+	url = https://github.com/boostorg/convert.git
 	branch = develop
 [submodule "endian"]
 	path = libs/endian
-	url = ../endian.git
+	url = https://github.com/boostorg/endian.git
 	fetchRecurseSubmodules = on-demand
 [submodule "vmd"]
 	path = libs/vmd
-	url = ../vmd.git
+	url = https://github.com/boostorg/vmd.git
 	fetchRecurseSubmodules = on-demand

--- a/emscripten.bat
+++ b/emscripten.bat
@@ -1,0 +1,31 @@
+@echo off
+setlocal
+
+:: run bootstrap.bat if b2.exe is not available
+if not exist "b2.exe" call bootstrap.bat
+
+:: we need to activate emscripten tools-chain before building boost
+if "%EMSCRIPTEN%"=="" (
+    ECHO.
+    ECHO Failed to find Emscripten SDK
+    ECHO Please activate Emscripten SDK by calling "emsdk activate ..."
+    goto :end
+)
+
+:: generate project-config.jam for emscripten build
+set toolset=emscripten
+set _emcc=%EMSCRIPTEN%\em++.bat
+set emcc=%_emcc:\=/%
+
+ECHO import option ; > project-config.jam
+ECHO. >> project-config.jam
+ECHO using %toolset% : : %emcc% ; >> project-config.jam
+ECHO using msvc ; >> project-config.jam
+ECHO. >> project-config.jam
+ECHO option.set keep-going : false ; >> project-config.jam
+ECHO. >> project-config.jam
+
+:: build boost system filesystem only
+b2 toolset=emscripten link=static variant=debug,release threading=single -d+2 system filesystem
+
+:end

--- a/emscripten.jam
+++ b/emscripten.jam
@@ -1,0 +1,143 @@
+# Boost.Build support for Emscipten.
+
+import generators ;
+import type ;
+import toolset ;
+import feature ;
+import common ;
+import errors ;
+
+if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ]
+{
+  .debug-configuration = true ;
+}
+
+# add an emscripten toolset
+feature.extend toolset : emscripten ;
+
+# extend the target-os list to include emscripten
+feature.extend target-os : emscripten ;
+# make emscripten the default target-os when compiling with the emscripten toolset
+feature.set-default target-os : emscripten ;
+
+# initialize the emscripten toolset
+rule init ( version ? : command * : options * )
+{  
+  root = ;
+  if $(command)
+  {    
+    root = $(command:D) ;
+  }
+  
+  local condition = [ common.check-init-parameters emscripten : version $(version) ] ;
+
+  common.handle-options emscripten : $(condition) : $(command) : $(options) ;
+  
+  # @todo this seems to be the right way, but this is a list somehow
+  toolset.add-requirements <toolset>emscripten:<testing.launcher>node ;
+  toolset.flags emscripten.compile STDHDRS $(condition) : $(root)/system/include ;
+  toolset.flags emscripten.link STDLIBPATH $(condition) : $(root)/system/lib ;
+  toolset.flags emscripten AR $(condition) : $(root)/emar.bat ;  
+  toolset.flags emscripten RANLIB $(condition) : $(root)/emranlib.bat ;
+}
+
+type.set-generated-target-suffix EXE : <toolset>emscripten : js ;
+#type.set-generated-target-suffix STATIC_LIB : <toolset>emscripten : bc ;
+#type.set-generated-target-suffix SHARED_LIB : <toolset>emscripten : bc ;
+#type.set-generated-target-suffix OBJ : <toolset>emscripten : bc ;
+
+generators.register-linker emscripten.link : OBJ STATIC_LIB : EXE : <toolset>emscripten ;
+
+generators.register-archiver emscripten.archive : OBJ : STATIC_LIB : <toolset>emscripten ;
+
+generators.register-c-compiler emscripten.compile.c++.preprocess : CPP : PREPROCESSED_CPP : <toolset>emscripten ;
+generators.register-c-compiler emscripten.compile.c.preprocess   : C   : PREPROCESSED_C   : <toolset>emscripten ;
+generators.register-c-compiler emscripten.compile.c++ : CPP : OBJ : <toolset>emscripten ;
+generators.register-c-compiler emscripten.compile.c : C : OBJ : <toolset>emscripten ;
+
+# Declare flags
+
+# align build flags with ACAD CMake build
+toolset.flags emscripten.compile OPTIONS <optimization>off   : -std=c++11 -stdlib=libc++ -fstrict-aliasing -O2 ;
+toolset.flags emscripten.compile OPTIONS <optimization>speed : -std=c++11 -stdlib=libc++ -fstrict-aliasing -O3 ;
+toolset.flags emscripten.compile OPTIONS <optimization>space : -std=c++11 -stdlib=libc++ -fstrict-aliasing -Os ;
+
+toolset.flags emscripten.compile OPTIONS <inlining>off  : -fno-inline ;
+toolset.flags emscripten.compile OPTIONS <inlining>on   : -Wno-inline ;
+toolset.flags emscripten.compile OPTIONS <inlining>full : -Wno-inline ;
+
+toolset.flags emscripten.compile OPTIONS <warnings>off : -w ;
+toolset.flags emscripten.compile OPTIONS <warnings>on  : -Wall -Wno-backslash-newline-escape -Wno-warn-absolute-paths -Wno-unused-function -Wno-overloaded-virtual ;
+toolset.flags emscripten.compile OPTIONS <warnings>all : -Wall -pedantic ;
+toolset.flags emscripten.compile OPTIONS <warnings-as-errors>on : -Werror ;
+
+toolset.flags emscripten.compile OPTIONS <debug-symbols>on : -g ;
+toolset.flags emscripten.compile OPTIONS <profiling>on : -pg ;
+
+toolset.flags emscripten.compile.c++ OPTIONS <rtti>off : -fno-rtti ;
+toolset.flags emscripten.compile.c++ OPTIONS <exception-handling>off : -fno-exceptions ;
+
+toolset.flags emscripten.compile USER_OPTIONS <cflags> ;
+toolset.flags emscripten.compile.c++ USER_OPTIONS <cxxflags> ;
+toolset.flags emscripten.compile DEFINES <define> ;
+toolset.flags emscripten.compile INCLUDES <include> ;
+toolset.flags emscripten.compile.c++ TEMPLATE_DEPTH <c++-template-depth> ;
+toolset.flags emscripten.compile.fortran USER_OPTIONS <fflags> ;
+
+toolset.flags emscripten.link DEFAULTS : -Wno-warn-absolute-paths ;
+
+toolset.flags emscripten.link LIBRARY_PATH <library-path> ;
+toolset.flags emscripten.link FINDLIBS_ST <find-static-library> ;
+toolset.flags emscripten.link FINDLIBS_SA <find-shared-library> ;
+toolset.flags emscripten.link LIBRARIES <library-file> ;
+
+toolset.flags emscripten.link OPTIONS <linkflags> ;
+
+toolset.flags emscripten.archive AROPTIONS <archiveflags> ;
+
+rule compile.c++ ( targets * : sources * : properties * )
+{
+    # Some extensions are compiled as C++ by default. For others, we need to
+    # pass -x c++. We could always pass -x c++ but distcc does not work with it.
+    if ! $(>:S) in .cc .cp .cxx .cpp .c++ .C
+    {
+        LANG on $(<) = "-x c++" ;
+    }
+}
+
+rule compile.c ( targets * : sources * : properties * )
+{
+    LANG on $(<) = "-x c" ;
+}
+
+actions compile.c++
+{
+    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<:W)" "$(>:W)"
+}
+
+actions compile.c
+{
+    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+}
+
+actions compile.c++.preprocess
+{
+    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" "$(>:W)" -E >"$(<:W)"
+}
+
+actions compile.c.preprocess
+{
+    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" "$(>)" -E >$(<)
+}
+
+actions link
+{
+  "$(CONFIG_COMMAND)" $(DEFAULTS) $(OPTIONS) -L"$(LIBRARY_PATH:W)" -L"$(STDLIBPATH:W)" -o "$(<:W)" "$(>:W)" -l"$(LIBRARIES:W)" -l"$(STDLIBRARIES:W)"
+}
+
+RM = [ common.rm-command ] ;
+actions piecemeal archive
+{
+  $(RM) "$(<)"
+  $(AR) rc "$(<:W)" "$(>:W)"
+}


### PR DESCRIPTION
please make sure you have activated emscripten SDK before building boost for Web. To build boost filesystem using Emscripten:
- Open Windows console
- Activate Emscripten. In AutoCAD build environment, you could invoke "cmakebuild/script/web/amake.bat activate" or in standaline emscripten, invoke "emsdk activate" to activate emscripten.
- Call Emscripten.bat
